### PR TITLE
pequeñas modificaciones y facs añadidos para prohd0016.xml

### DIFF
--- a/prohd0016.xml
+++ b/prohd0016.xml
@@ -61,6 +61,7 @@
                 <language ident="es">Español</language>
             </langUsage>
             <abstract xml:lang="es">
+                <!-- esto requiere una revisión, porque más bien parece que la petición de Ana de Toro y la sobre la prohibición del Ensayo son dos actos separados -->
                 <p>Solicitud hecha al Gobernador y Capitán General sobre licencia que presentó la
                     morena libre Ana del Toro para establecer una escuela de primeras letras a niños
                     de color y utilizar como material de enseñanza el "Ensayo Político de la Isla de
@@ -81,19 +82,11 @@
                     </category>
                     <category xml:id="form">
                         <category xml:id="manuscript"/>
-                        <category xml:id="print"/>
                     </category>
                     <category xml:id="subjects">
-                        <category xml:id="climatology"/>
                         <category xml:id="colonialism"/>
                         <category xml:id="demography"/>
-                        <category xml:id="economicconditions"/>
-                        <category xml:id="geography"/>
-                        <category xml:id="medicine"/>
                         <category xml:id="science"/>
-                        <category xml:id="plantations"/>
-                        <category xml:id="coffee"/>
-                        <category xml:id="sugar"/>
                         <category xml:id="slavery"/>
                         <category xml:id="trade"/>
                         <category xml:id="emancipation"/>
@@ -104,7 +97,7 @@
     </teiHeader>
     <text>
         <body>
-            <pb n="1"/>
+            <pb n="1" facs="0001.xml"/>
             <div type="writingSession" n="1">
                 <opener>
                     <dateline>1827</dateline>
@@ -253,7 +246,7 @@
                         <expan>Excelentísimo</expan>
                     </choice>
                     <lb/>Ayuntamiento, <choice>
-                        <orig>compre- <lb/>hende</orig>
+                        <orig>compre<g ref="#typoHyphen"/><lb break="no"/>hende</orig>
                         <reg>comprende</reg>
                     </choice> dos particulares; <lb/>el <choice>
                         <abbr>prim.<hi rendition="#sup">o</hi></abbr>
@@ -274,7 +267,7 @@
                         <orig>á</orig>
                         <reg>a</reg>
                     </choice> la morena libre 
-                    <lb/><pb n="2"/>Ana del Toro para establecer una <choice>
+                    <lb/><pb n="2" facs="0002.tif"/>Ana del Toro para establecer una <choice>
                         <orig>Escuela</orig>
                         <reg>escuela</reg>
                     </choice>
@@ -341,7 +334,7 @@
                     </choice>. <choice>
                         <abbr>V E.</abbr>
                         <expan>Vuestra Excelencia</expan>
-                    </choice> sin em <lb/>bargo resolverá lo que estime</p>
+                    </choice> sin em<lb break="no"/>bargo resolverá lo que estime</p>
                
             </div>
         </body>


### PR DESCRIPTION
Es lo que he hecho o quisiera comentar:

- El abstract requiere una revisión por parte de Alaina y Grisel (Email TK a todos, 02.12.21). 
- Incluí los valores de `@facs` en `<pb/>` a base del nuevo escaneo de la OHC (Nov 21) que mandó Alaina. 
-- Para ello, transformé las dos páginas del PDF original en TIFF y en PTIF (pyramidal tiff)
-- no sé si lo he hecho bien, pero usé una herramienta en línea, [Vertopal](https://www.vertopal.com/en/picture/convert/tif-to-ptif)
-- los archivos tif y ptif se encuentran en Nextcloud\CENTRO_ProHD\Korpus\Quellen\OHCH\Consulta a gobernador (Ana del Toro)\2021-11-11 nuevo scan
-- en el código, usé los TIFs regulares a base de una enumeración con cuatro digitos
El resto son cambios más bien pequeños.