### PR TITLE
small transcription error

### DIFF
--- a/prohd0025.xml
+++ b/prohd0025.xml
@@ -801,7 +801,7 @@
                         <abbr>q.</abbr>
                         <expan>que</expan>
                     </choice>
-                    <lb/>en los de <choice>
+                    <lb/>en la de <choice>
                         <abbr>D.</abbr>
                         <expan>Don</expan>
                     </choice> José <choice>


### PR DESCRIPTION
"en la de" instead of "en los de" meaning "en la [libreria] de"